### PR TITLE
Add period navigation and improve log view UI

### DIFF
--- a/Pomodoro/FocusLogEntry.swift
+++ b/Pomodoro/FocusLogEntry.swift
@@ -29,4 +29,13 @@ extension PomodoroState {
         case .idle: .gray
         }
     }
+
+    var symbolName: String {
+        switch self {
+        case .idle: "hourglass"
+        case .focus: "timer"
+        case .shortBreak: "cup.and.saucer"
+        case .longBreak: "sparkles"
+        }
+    }
 }

--- a/Pomodoro/LogChartView.swift
+++ b/Pomodoro/LogChartView.swift
@@ -15,19 +15,20 @@ struct AggregatedLogData: Identifiable {
 
 struct LogChartView: View {
     let period: TimePeriod
+    let offset: Int
     @Query private var logs: [FocusLogEntry]
 
-    init(period: TimePeriod) {
+    init(period: TimePeriod, offset: Int = 0) {
         self.period = period
-        // [수정됨] .ascending을 .forward로 변경하여 SwiftData @Query 문법에 맞게 수정
-        _logs = Query(filter: period.predicate, sort: \.startTime, order: .forward)
+        self.offset = offset
+        _logs = Query(filter: period.predicate(offset: offset), sort: \.startTime, order: .forward)
     }
 
-    private var chartData: [AggregatedLogData] {
+    // 주/월 뷰: 일별 집계
+    private var dailyChartData: [AggregatedLogData] {
         let groupedLogs = Dictionary(grouping: logs) { log in
             DateHelper.startOfDayUTC(for: log.startTime)
         }
-        
         var aggregatedData = [Date: AggregatedLogData]()
         for (date, logsInGroup) in groupedLogs {
             var data = AggregatedLogData(id: date, date: date)
@@ -44,33 +45,74 @@ struct LogChartView: View {
         return aggregatedData.values.sorted { $0.date < $1.date }
     }
 
+    // 전체 기록 뷰: 월별 집계
+    private var monthlyChartData: [AggregatedLogData] {
+        let calendar = Calendar.current
+        let groupedLogs = Dictionary(grouping: logs) { log -> Date in
+            let comps = calendar.dateComponents([.year, .month], from: log.startTime)
+            return calendar.date(from: comps) ?? log.startTime
+        }
+        var aggregatedData = [Date: AggregatedLogData]()
+        for (date, logsInGroup) in groupedLogs {
+            var data = AggregatedLogData(id: date, date: date)
+            for log in logsInGroup {
+                switch log.sessionType {
+                case .focus: data.focusDuration += log.duration
+                case .shortBreak: data.shortBreakDuration += log.duration
+                case .longBreak: data.longBreakDuration += log.duration
+                default: break
+                }
+            }
+            aggregatedData[date] = data
+        }
+        return aggregatedData.values.sorted { $0.date < $1.date }
+    }
+
+    private var chartData: [AggregatedLogData] {
+        period == .all ? monthlyChartData : dailyChartData
+    }
+
     private var totalFocusTimeForPeriod: TimeInterval {
         logs.filter { $0.sessionType == .focus }.reduce(0) { $0 + $1.duration }
     }
 
+    private var chartTitle: String {
+        switch period {
+        case .all: return "전체 집중 기록 (월별)"
+        default: return "\(period.dateRangeLabel(offset: offset)) 집중 시간 분석"
+        }
+    }
+
     var body: some View {
         VStack {
-            Text("\(period.rawValue) 집중 시간 분석").font(.title2).padding()
-            
+            Text(chartTitle)
+                .font(.title2)
+                .padding()
+
             Text("총 집중 시간: \(formatTimeInterval(totalFocusTimeForPeriod))")
-                .font(.headline).foregroundStyle(.secondary).padding(.bottom)
+                .font(.headline)
+                .foregroundStyle(.secondary)
+                .padding(.bottom)
 
             if chartData.isEmpty {
                 ContentUnavailableView("선택된 기간에 기록이 없습니다", systemImage: "chart.bar.xaxis")
             } else {
+                let xUnit: Calendar.Component = period == .all ? .month : .day
+                let xCount = period == .monthly ? 7 : 1
+
                 Chart(chartData) { data in
                     BarMark(
-                        x: .value("Date", data.date, unit: .day),
+                        x: .value("Date", data.date, unit: xUnit),
                         y: .value("Minutes", data.focusDuration / 60)
                     ).foregroundStyle(by: .value("Type", PomodoroState.focus.rawValue))
-                    
+
                     BarMark(
-                        x: .value("Date", data.date, unit: .day),
+                        x: .value("Date", data.date, unit: xUnit),
                         y: .value("Minutes", data.shortBreakDuration / 60)
                     ).foregroundStyle(by: .value("Type", PomodoroState.shortBreak.rawValue))
-                    
+
                     BarMark(
-                        x: .value("Date", data.date, unit: .day),
+                        x: .value("Date", data.date, unit: xUnit),
                         y: .value("Minutes", data.longBreakDuration / 60)
                     ).foregroundStyle(by: .value("Type", PomodoroState.longBreak.rawValue))
                 }
@@ -88,11 +130,15 @@ struct LogChartView: View {
                     }
                 }
                 .chartXAxis {
-                    AxisMarks(values: .stride(by: .day, count: period == .monthly ? 7 : 1 )) { value in
+                    AxisMarks(values: .stride(by: xUnit, count: xCount)) { value in
                         AxisGridLine()
                         AxisTick()
-                        if let date = value.as(Date.self) {
-                            AxisValueLabel(format: .dateTime.month(.abbreviated).day(), centered: true)
+                        if value.as(Date.self) != nil {
+                            if period == .all {
+                                AxisValueLabel(format: .dateTime.month(.abbreviated).year(.twoDigits))
+                            } else {
+                                AxisValueLabel(format: .dateTime.month(.abbreviated).day(), centered: true)
+                            }
                         }
                     }
                 }
@@ -101,7 +147,7 @@ struct LogChartView: View {
         }
         .frame(minWidth: 400, minHeight: 300)
     }
-    
+
     private func formatTimeInterval(_ interval: TimeInterval) -> String {
         let hours = Int(interval) / 3600
         let minutes = (Int(interval) % 3600) / 60

--- a/Pomodoro/LogView.swift
+++ b/Pomodoro/LogView.swift
@@ -6,14 +6,24 @@ import SwiftData
 
 struct LogView: View {
     @State private var selectedPeriod: TimePeriod = .weekly
+    @State private var periodOffset: Int = 0
     @State private var showingDeleteAlert = false
     @Environment(\.modelContext) private var modelContext
-    @Environment(\.dismissWindow) private var dismissWindow
+
+    private var periodBinding: Binding<TimePeriod> {
+        Binding(
+            get: { selectedPeriod },
+            set: { newValue in
+                selectedPeriod = newValue
+                periodOffset = 0
+            }
+        )
+    }
 
     var body: some View {
         NavigationSplitView {
             VStack(spacing: 0) {
-                Picker("기간 선택", selection: $selectedPeriod) {
+                Picker("기간 선택", selection: periodBinding) {
                     ForEach(TimePeriod.allCases) { period in
                         Text(period.rawValue).tag(period)
                     }
@@ -21,10 +31,15 @@ struct LogView: View {
                 .pickerStyle(.segmented)
                 .padding()
 
-                FilteredLogListView(period: selectedPeriod)
+                if selectedPeriod != .all {
+                    PeriodNavigationBar(period: selectedPeriod, offset: $periodOffset)
+                    FilteredLogListView(period: selectedPeriod, offset: periodOffset)
+                } else {
+                    AllRecordsSummaryView()
+                }
             }
             .navigationTitle("집중 기록")
-            .frame(minWidth: 400)
+            .frame(minWidth: 320)
             .toolbar {
                 ToolbarItem {
                     Button(role: .destructive) {
@@ -41,13 +56,7 @@ struct LogView: View {
                 Text("이 동작은 되돌릴 수 없습니다.")
             }
         } detail: {
-            LogChartView(period: selectedPeriod)
-        }
-        // 윈도우가 포커스를 잃으면 자동으로 닫기
-        .onReceive(NotificationCenter.default.publisher(for: NSWindow.didResignKeyNotification)) { notification in
-            guard let window = notification.object as? NSWindow,
-                  window.title == "집중 기록" else { return }
-            dismissWindow(id: "log-window")
+            LogChartView(period: selectedPeriod, offset: periodOffset)
         }
     }
 
@@ -56,12 +65,138 @@ struct LogView: View {
     }
 }
 
+// MARK: - Period Navigation Bar
+
+struct PeriodNavigationBar: View {
+    let period: TimePeriod
+    @Binding var offset: Int
+
+    var body: some View {
+        HStack {
+            Button {
+                offset -= 1
+            } label: {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 13, weight: .semibold))
+            }
+            .buttonStyle(.plain)
+
+            Spacer()
+
+            Text(period.dateRangeLabel(offset: offset))
+                .font(.subheadline)
+                .fontWeight(.medium)
+
+            Spacer()
+
+            Button {
+                offset += 1
+            } label: {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 13, weight: .semibold))
+            }
+            .buttonStyle(.plain)
+            .disabled(offset >= 0)
+        }
+        .padding(.horizontal, 16)
+        .padding(.bottom, 8)
+    }
+}
+
+// MARK: - All Records Summary (전체 기록 탭 사이드바)
+
+struct AllRecordsSummaryView: View {
+    @Query private var logs: [FocusLogEntry]
+
+    private var totalFocusSessions: Int {
+        logs.filter { $0.sessionType == .focus }.count
+    }
+
+    private var totalFocusTime: TimeInterval {
+        logs.filter { $0.sessionType == .focus }.reduce(0) { $0 + $1.duration }
+    }
+
+    private var totalBreakTime: TimeInterval {
+        logs.filter { $0.sessionType == .shortBreak || $0.sessionType == .longBreak }
+            .reduce(0) { $0 + $1.duration }
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                Spacer(minLength: 20)
+                StatCard(
+                    title: "총 집중 세션",
+                    value: "\(totalFocusSessions)회",
+                    systemImage: "timer",
+                    color: .blue
+                )
+                StatCard(
+                    title: "총 집중 시간",
+                    value: formatTime(totalFocusTime),
+                    systemImage: "brain.head.profile",
+                    color: .blue
+                )
+                StatCard(
+                    title: "총 휴식 시간",
+                    value: formatTime(totalBreakTime),
+                    systemImage: "cup.and.saucer",
+                    color: .green
+                )
+                Spacer(minLength: 20)
+            }
+            .padding()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func formatTime(_ interval: TimeInterval) -> String {
+        let hours = Int(interval) / 3600
+        let minutes = (Int(interval) % 3600) / 60
+        if hours > 0 {
+            return "\(hours)시간 \(minutes)분"
+        } else {
+            return "\(minutes)분"
+        }
+    }
+}
+
+struct StatCard: View {
+    let title: String
+    let value: String
+    let systemImage: String
+    let color: Color
+
+    var body: some View {
+        HStack(spacing: 16) {
+            Image(systemName: systemImage)
+                .font(.title2)
+                .foregroundStyle(color)
+                .frame(width: 32)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(value)
+                    .font(.title3)
+                    .fontWeight(.bold)
+                    .foregroundStyle(.primary)
+            }
+            Spacer()
+        }
+        .padding()
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: 10))
+    }
+}
+
+// MARK: - Filtered Log List View
+
 struct FilteredLogListView: View {
     @Query private var logs: [FocusLogEntry]
-    @Environment(\.managedObjectContext) private var viewContext
     @Environment(\.modelContext) private var modelContext
-    init(period: TimePeriod) {
-        _logs = Query(filter: period.predicate, sort: \.startTime, order: .reverse)
+
+    init(period: TimePeriod, offset: Int) {
+        _logs = Query(filter: period.predicate(offset: offset), sort: \.startTime, order: .reverse)
     }
 
     private var groupedLogs: [Date: [FocusLogEntry]] {
@@ -69,11 +204,11 @@ struct FilteredLogListView: View {
             DateHelper.startOfDayUTC(for: log.startTime)
         }
     }
-    
+
     private var sortedDays: [Date] {
         groupedLogs.keys.sorted(by: >)
     }
-    
+
     var body: some View {
         List {
             ForEach(sortedDays, id: \.self) { day in
@@ -81,10 +216,10 @@ struct FilteredLogListView: View {
                     ForEach(groupedLogs[day] ?? []) { log in
                         LogEntryRow(log: log)
                     }
-                    .onDelete{ indexSet in guard let dayLogs = groupedLogs[day] else {return}
+                    .onDelete { indexSet in
+                        guard let dayLogs = groupedLogs[day] else { return }
                         for index in indexSet {
-                            let logToDelete = dayLogs[index]
-                            modelContext.delete(logToDelete)
+                            modelContext.delete(dayLogs[index])
                         }
                     }
                 } header: {
@@ -96,21 +231,30 @@ struct FilteredLogListView: View {
     }
 }
 
+// MARK: - Log Entry Row
+
 struct LogEntryRow: View {
     let log: FocusLogEntry
-    private var timeFormatter: DateFormatter {
+
+    private static let timeFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "HH:mm"
         return formatter
-    }
+    }()
 
     var body: some View {
         HStack(spacing: 12) {
-            Rectangle().fill(log.sessionType.color).frame(width: 5)
-            Text(log.sessionType.emoji).font(.title2)
-            VStack(alignment: .leading) {
+            Rectangle()
+                .fill(log.sessionType.color)
+                .frame(width: 4)
+                .clipShape(Capsule())
+            Image(systemName: log.sessionType.symbolName)
+                .font(.title3)
+                .foregroundStyle(log.sessionType.color)
+                .frame(width: 24)
+            VStack(alignment: .leading, spacing: 2) {
                 Text(log.sessionType.rawValue).fontWeight(.bold)
-                Text("\(timeFormatter.string(from: log.startTime)) - \(timeFormatter.string(from: log.startTime.addingTimeInterval(log.duration)))")
+                Text("\(LogEntryRow.timeFormatter.string(from: log.startTime)) - \(LogEntryRow.timeFormatter.string(from: log.startTime.addingTimeInterval(log.duration)))")
                     .font(.caption).foregroundStyle(.secondary)
             }
             Spacer()
@@ -122,14 +266,16 @@ struct LogEntryRow: View {
     }
 }
 
+// MARK: - Log Section Header
+
 struct LogSectionHeader: View {
     let day: Date
     let logs: [FocusLogEntry]
-    
+
     private var totalFocusTime: TimeInterval {
         logs.filter { $0.sessionType == .focus }.reduce(0) { $0 + $1.duration }
     }
-    
+
     var body: some View {
         HStack {
             Text(day.formatted(.dateTime.year().month().day().weekday(.wide)))
@@ -143,23 +289,55 @@ struct LogSectionHeader: View {
     }
 }
 
+// MARK: - TimePeriod Enum
+
 enum TimePeriod: String, CaseIterable, Identifiable {
     case weekly = "이번 주", monthly = "이번 달", all = "전체 기록"
     var id: Self { self }
 
-    var predicate: Predicate<FocusLogEntry>? {
+    func predicate(offset: Int = 0) -> Predicate<FocusLogEntry>? {
         let calendar = Calendar.current
         let now = Date()
-        
+
         switch self {
         case .weekly:
-            guard let startOfWeek = calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: now)) else { return nil }
-            return #Predicate<FocusLogEntry> { $0.startTime >= startOfWeek }
+            guard let startOfThisWeek = calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: now)),
+                  let startDate = calendar.date(byAdding: .weekOfYear, value: offset, to: startOfThisWeek),
+                  let endDate = calendar.date(byAdding: .weekOfYear, value: 1, to: startDate)
+            else { return nil }
+            return #Predicate<FocusLogEntry> { $0.startTime >= startDate && $0.startTime < endDate }
         case .monthly:
-            guard let startOfMonth = calendar.date(from: calendar.dateComponents([.year, .month], from: now)) else { return nil }
-            return #Predicate<FocusLogEntry> { $0.startTime >= startOfMonth }
+            guard let startOfThisMonth = calendar.date(from: calendar.dateComponents([.year, .month], from: now)),
+                  let startDate = calendar.date(byAdding: .month, value: offset, to: startOfThisMonth),
+                  let endDate = calendar.date(byAdding: .month, value: 1, to: startDate)
+            else { return nil }
+            return #Predicate<FocusLogEntry> { $0.startTime >= startDate && $0.startTime < endDate }
         case .all:
             return nil
+        }
+    }
+
+    func dateRangeLabel(offset: Int) -> String {
+        let calendar = Calendar.current
+        let now = Date()
+        let formatter = DateFormatter()
+
+        switch self {
+        case .weekly:
+            guard let startOfThisWeek = calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: now)),
+                  let startDate = calendar.date(byAdding: .weekOfYear, value: offset, to: startOfThisWeek),
+                  let endDate = calendar.date(byAdding: .day, value: 6, to: startDate)
+            else { return "" }
+            formatter.dateFormat = "M.d"
+            return "\(formatter.string(from: startDate)) - \(formatter.string(from: endDate))"
+        case .monthly:
+            guard let startOfThisMonth = calendar.date(from: calendar.dateComponents([.year, .month], from: now)),
+                  let startDate = calendar.date(byAdding: .month, value: offset, to: startOfThisMonth)
+            else { return "" }
+            formatter.dateFormat = "yyyy년 M월"
+            return formatter.string(from: startDate)
+        case .all:
+            return "전체 기록"
         }
     }
 }

--- a/Pomodoro/StatusBarView.swift
+++ b/Pomodoro/StatusBarView.swift
@@ -7,15 +7,15 @@ struct StatusBarView: View {
     @EnvironmentObject var viewModel: PomodoroViewModel
 
     var body: some View {
-        HStack(spacing: 5) {
-            Text(viewModel.currentState.emoji)
-                .font(.system(size: 18))
-            
+        HStack(spacing: 4) {
+            Image(systemName: viewModel.currentState.symbolName)
+                .imageScale(.medium)
+
             if viewModel.timerState == .running || viewModel.timerState == .paused {
                 BatteryProgressBar(progress: viewModel.progress, color: viewModel.currentState.color)
             }
         }
-        .padding(.horizontal, 8)
+        .padding(.horizontal, 6)
         .fixedSize()
     }
 }
@@ -23,20 +23,28 @@ struct StatusBarView: View {
 struct BatteryProgressBar: View {
     var progress: Double
     var color: Color
-    
+
     var body: some View {
-        ZStack(alignment: .leading) {
-            RoundedRectangle(cornerRadius: 3.5)
-                .stroke(Color.primary.opacity(0.8), lineWidth: 1.5)
-            
-            GeometryReader { geometry in
-                let fillWidth = (geometry.size.width - 3) * CGFloat(progress)
-                RoundedRectangle(cornerRadius: 2)
-                    .fill(color)
-                    .frame(width: fillWidth)
-                    .padding(1.5)
+        HStack(spacing: 1.5) {
+            ZStack(alignment: .leading) {
+                RoundedRectangle(cornerRadius: 3)
+                    .stroke(Color.primary.opacity(0.6), lineWidth: 1.5)
+
+                GeometryReader { geometry in
+                    let maxFillWidth = geometry.size.width - 3
+                    let fillWidth = max(0, maxFillWidth * CGFloat(progress))
+                    RoundedRectangle(cornerRadius: 1.5)
+                        .fill(color)
+                        .frame(width: fillWidth)
+                        .padding(1.5)
+                }
             }
+            .frame(width: 28, height: 13)
+
+            // Battery terminal nub
+            RoundedRectangle(cornerRadius: 1)
+                .fill(Color.primary.opacity(0.6))
+                .frame(width: 2, height: 6)
         }
-        .frame(width: 35, height: 14)
     }
 }


### PR DESCRIPTION
## Summary
Enhanced the LogView with period navigation capabilities, allowing users to browse previous/future weeks and months. Refactored the log display to show different views for time-period filters versus all-time records, and improved UI consistency across components.

## Key Changes

### LogView.swift
- Added `periodOffset` state to track navigation through time periods
- Implemented custom `periodBinding` that resets offset when period selection changes
- Added `PeriodNavigationBar` component with left/right chevron buttons to navigate between weeks/months
- Created `AllRecordsSummaryView` to display aggregate statistics (total sessions, focus time, break time) for the "all records" tab
- Added `StatCard` component for displaying summary statistics
- Updated `FilteredLogListView` to accept `offset` parameter and pass it to the predicate
- Removed automatic window dismissal logic (NSWindow notification handling)
- Reduced minimum sidebar width from 400 to 320
- Improved code organization with MARK comments for better readability
- Enhanced `LogEntryRow` with SF Symbols instead of emoji, improved styling with capsule-shaped indicator
- Made `timeFormatter` a static property for efficiency

### LogChartView.swift
- Added `offset` parameter to support period navigation
- Implemented separate `dailyChartData` (for weekly/monthly views) and `monthlyChartData` (for all-time view) aggregation methods
- Added dynamic chart title that reflects the selected period and offset
- Updated chart x-axis to use `.month` unit for all-time view and `.day` for period views
- Improved axis label formatting to show month/year for all-time view and month/day for period views
- Enhanced chart stride calculation based on period type

### StatusBarView.swift
- Replaced emoji indicators with SF Symbols for consistency
- Improved battery progress bar styling with better proportions and a terminal nub
- Adjusted spacing and padding for better visual balance

### FocusLogEntry.swift
- Added `symbolName` computed property to `PomodoroState` extension for SF Symbol support across the app
- Maps each state to appropriate system icons (hourglass, timer, cup.and.saucer, sparkles)

## Notable Implementation Details
- Period navigation is disabled for future periods (offset >= 0) via the `disabled` modifier
- The predicate system now supports offset-based date range calculations for both weekly and monthly periods
- Chart data aggregation adapts based on period type: daily for weeks/months, monthly for all-time records
- All time-related formatting is centralized in the `TimePeriod` enum for maintainability

https://claude.ai/code/session_01YC38aemFz3t7irh6AzSUys