### PR TITLE
Improve status bar progress indicator and add daily average stats

### DIFF
--- a/Pomodoro/LogView.swift
+++ b/Pomodoro/LogView.swift
@@ -121,6 +121,22 @@ struct AllRecordsSummaryView: View {
             .reduce(0) { $0 + $1.duration }
     }
 
+    private var activeDayCount: Int {
+        let focusLogs = logs.filter { $0.sessionType == .focus }
+        let uniqueDays = Set(focusLogs.map { Calendar.current.startOfDay(for: $0.startTime) })
+        return uniqueDays.count
+    }
+
+    private var dailyAverageFocusTime: TimeInterval {
+        guard activeDayCount > 0 else { return 0 }
+        return totalFocusTime / Double(activeDayCount)
+    }
+
+    private var dailyAverageSessions: Double {
+        guard activeDayCount > 0 else { return 0 }
+        return Double(totalFocusSessions) / Double(activeDayCount)
+    }
+
     var body: some View {
         ScrollView {
             VStack(spacing: 16) {
@@ -142,6 +158,18 @@ struct AllRecordsSummaryView: View {
                     value: formatTime(totalBreakTime),
                     systemImage: "cup.and.saucer",
                     color: .green
+                )
+                StatCard(
+                    title: "일 평균 집중 시간",
+                    value: activeDayCount > 0 ? formatTime(dailyAverageFocusTime) : "-",
+                    systemImage: "clock.arrow.circlepath",
+                    color: .orange
+                )
+                StatCard(
+                    title: "일 평균 집중 세션",
+                    value: activeDayCount > 0 ? String(format: "%.1f회", dailyAverageSessions) : "-",
+                    systemImage: "calendar.badge.clock",
+                    color: .orange
                 )
                 Spacer(minLength: 20)
             }

--- a/Pomodoro/StatusBarView.swift
+++ b/Pomodoro/StatusBarView.swift
@@ -9,10 +9,11 @@ struct StatusBarView: View {
     var body: some View {
         HStack(spacing: 4) {
             Image(systemName: viewModel.currentState.symbolName)
-                .imageScale(.medium)
+                .imageScale(.large)
+                .foregroundStyle(.primary)
 
             if viewModel.timerState == .running || viewModel.timerState == .paused {
-                BatteryProgressBar(progress: viewModel.progress, color: viewModel.currentState.color)
+                LinearProgressBar(progress: viewModel.progress, color: viewModel.currentState.color)
             }
         }
         .padding(.horizontal, 6)
@@ -20,31 +21,18 @@ struct StatusBarView: View {
     }
 }
 
-struct BatteryProgressBar: View {
+struct LinearProgressBar: View {
     var progress: Double
     var color: Color
 
     var body: some View {
-        HStack(spacing: 1.5) {
-            ZStack(alignment: .leading) {
-                RoundedRectangle(cornerRadius: 3)
-                    .stroke(Color.primary.opacity(0.6), lineWidth: 1.5)
-
-                GeometryReader { geometry in
-                    let maxFillWidth = geometry.size.width - 3
-                    let fillWidth = max(0, maxFillWidth * CGFloat(progress))
-                    RoundedRectangle(cornerRadius: 1.5)
-                        .fill(color)
-                        .frame(width: fillWidth)
-                        .padding(1.5)
-                }
-            }
-            .frame(width: 28, height: 13)
-
-            // Battery terminal nub
-            RoundedRectangle(cornerRadius: 1)
-                .fill(Color.primary.opacity(0.6))
-                .frame(width: 2, height: 6)
+        ZStack(alignment: .leading) {
+            Capsule()
+                .fill(Color.primary.opacity(0.15))
+                .frame(width: 34, height: 6)
+            Capsule()
+                .fill(color)
+                .frame(width: max(0, 34 * CGFloat(progress)), height: 6)
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR enhances the Pomodoro timer UI with a redesigned progress indicator and adds new daily average statistics to the log view.

## Key Changes

**StatusBarView.swift:**
- Replaced `BatteryProgressBar` with a new `LinearProgressBar` component featuring a cleaner capsule-based design
- Updated icon scale from `.medium` to `.large` and added explicit `.primary` foreground color
- Simplified progress bar implementation: removed the battery terminal nub and complex nested geometry calculations in favor of a straightforward capsule-based layout with 34pt width and 6pt height

**LogView.swift:**
- Added three new computed properties to `AllRecordsSummaryView`:
  - `activeDayCount`: Calculates the number of unique days with focus sessions
  - `dailyAverageFocusTime`: Computes average focus time per active day
  - `dailyAverageSessions`: Computes average number of focus sessions per active day
- Added two new stat cards displaying daily averages:
  - "일 평균 집중 시간" (Daily Average Focus Time) with clock icon
  - "일 평균 집중 세션" (Daily Average Sessions) with calendar icon
- Both new stats gracefully display "-" when no data is available

## Implementation Details
- The new `LinearProgressBar` uses `Capsule()` shapes for a modern, minimalist appearance
- Daily average calculations properly handle edge cases (zero active days) to prevent division errors
- New statistics are displayed with orange accent color to distinguish them from existing metrics

https://claude.ai/code/session_0158G8hR7EAsJaakWsp3WMHK